### PR TITLE
React 15.5 migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,16 @@
     "test:watch": "nwb test-react --server"
   },
   "dependencies": {
-    "ouibounce": "0.0.12"
+    "ouibounce": "0.0.12",
+    "prop-types": "^15.5.8"
   },
   "peerDependencies": {
     "react": "15.x"
   },
   "devDependencies": {
     "nwb": "0.15.x",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4"
   },
   "author": "Neehar Venugopal <neeharv@gmail.com>",
   "homepage": "",

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,18 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import ouibounce from 'ouibounce'
 
 class ReactOuibounce extends React.Component {
 
   static propTypes = {
-    sensitivity : React.PropTypes.number,
-    aggressive : React.PropTypes.bool,
-    timer : React.PropTypes.number,
-    delay : React.PropTypes.number,
-    cookieExpire : React.PropTypes.number,
-    cookieName : React.PropTypes.string,
-    cookieDomain : React.PropTypes.string,
-    sitewide : React.PropTypes.bool,
+    sensitivity : PropTypes.number,
+    aggressive : PropTypes.bool,
+    timer : PropTypes.number,
+    delay : PropTypes.number,
+    cookieExpire : PropTypes.number,
+    cookieName : PropTypes.string,
+    cookieDomain : PropTypes.string,
+    sitewide : PropTypes.bool,
   }
 
   state = {


### PR DESCRIPTION
Uses the [prop-types](https://github.com/reactjs/prop-types) library to remove deprecation warnings in React 15.5